### PR TITLE
Fix Catalyst build on macOS

### DIFF
--- a/SocketRocket/ARTSRWebSocket.m
+++ b/SocketRocket/ARTSRWebSocket.m
@@ -11,7 +11,7 @@
 
 #import "ARTSRWebSocket.h"
 
-#if TARGET_OS_IPHONE
+#if __has_include(<unicode/utf8.h>)
 #define HAS_ICU
 #endif
 


### PR DESCRIPTION
This applies the same patch from https://github.com/firebase/firebase-ios-sdk/pull/3512 to this project to fix a build error when building for Catalyst on macOS.

Might be related to https://github.com/ably/ably-cocoa/issues/1003 ?

I wasn't able to successfully build this in Xcode due to it not finding certain build files, however installing it as a pod and modifying it from within my own project with the same change allows my app to run as a Catalyst app.